### PR TITLE
Fix library import (because of numpy.typing issues)

### DIFF
--- a/src/gsffile/read.py
+++ b/src/gsffile/read.py
@@ -4,8 +4,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 
-import numpy.typing
 import numpy as np
+import numpy.typing
 
 from .format import (
     gsf_dtype,

--- a/src/gsffile/read.py
+++ b/src/gsffile/read.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 
+import numpy.typing
 import numpy as np
 
 from .format import (

--- a/src/gsffile/write.py
+++ b/src/gsffile/write.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+import numpy.typing
 import numpy as np
 
 from .format import (

--- a/src/gsffile/write.py
+++ b/src/gsffile/write.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from typing import Any
 
-import numpy.typing
 import numpy as np
+import numpy.typing
 
 from .format import (
     gsf_array_order,


### PR DESCRIPTION
Referencing numpy.typing without explicit import does not work on numpy 1.26.4. Importing gsffile thus fails.

This small fix fixes the problem for me.

```
>>> import numpy as np
>>> np.__version__
'1.26.4'
>>> np.typing
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/marko/venv310/lib/python3.10/site-packages/numpy/__init__.py", line 333, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'typing'. Did you mean: '_typing'?
>>> import numpy.typing
>>> np.typing
<module 'numpy.typing' from '/home/marko/venv310/lib/python3.10/site-packages/numpy/typing/__init__.py'>
```